### PR TITLE
back button on articles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1628,6 +1628,58 @@ input, select, textarea {
 
 		}
 
+		/* [BEGIN] CHILD ARTICLE TO INCLUDE BACK BUTTON UPPER-LEFT CORNER */
+			#main article .back {
+				display: block;
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 4rem;
+				height: 4rem;
+				cursor: pointer;
+				text-indent: 4rem;
+				overflow: hidden;
+				white-space: nowrap;
+			}
+
+				#main article .back:before {
+					-moz-transition: background-color 0.2s ease-in-out;
+					-webkit-transition: background-color 0.2s ease-in-out;
+					-ms-transition: background-color 0.2s ease-in-out;
+					transition: background-color 0.2s ease-in-out;
+					content: '';
+					display: inline-block;
+					position: absolute;
+					top: 0.75rem;
+					left: 0.75rem;
+					width: 2.5rem;
+					height: 2.5rem;
+					border-radius: 100%;
+					background-position: center;
+					background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='20px' height='20px' viewBox='0 0 20 20' zoomAndPan='disable'%3E%3Cstyle%3Eline %7B stroke: %23ffffff%3B stroke-width: 1%3B %7D%3C/style%3E%3Cline x1='2' y1='10' x2='18' y2='10' /%3E%3Cline x1='2' y1='10' x2='10' y2='2' /%3E%3Cline x1='2' y1='10' x2='10' y2='18' /%3E%3C/svg%3E");
+					background-size: 20px 20px;
+					background-repeat: no-repeat;
+				}
+
+                #main article .back:hover:before {
+					background-color: rgba(255, 255, 255, 0.075);
+				}
+
+				#main article .back:active:before {
+					background-color: rgba(255, 255, 255, 0.175);
+				}
+
+			@media screen and (max-width: 736px) {
+				#main article .back:before {
+					top: 0.875rem;
+					left: 0.875rem;
+					width: 2.25rem;
+					height: 2.25rem;
+					background-size: 14px 14px;
+				}
+		}
+		/* [END] CHILD ARTICLE TO INCLUDE BACK BUTTON UPPER-LEFT CORNER */
+
 /* Footer */
 
 	#footer {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -298,6 +298,13 @@
 							location.hash = '';
 						});
 
+				// Back.
+					$('<div class="back">Back</div>')
+						.appendTo($this)
+						.on('click', function() {
+							window.history.back();
+						});
+
 				// Prevent clicks from inside article from bubbling.
 					$this.on('click', function(event) {
 						event.stopPropagation();


### PR DESCRIPTION
Le back button fait faire un pas en arrière dans l'historique de navigation, c'est comme cliquer sur "reculer d'une page" dans le navigateur.
Du coup, pour les pages de niveau 1 ("Musique à l'image", "Autres projets",...), le back button équivaut au close button. Ce serait cool de ne le faire apparaître que sur les pages de niveau >1, mais je n'y arrive pas ^^